### PR TITLE
Add email OTP flows and auth routes

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -6,6 +6,8 @@ export default function AuthLayout() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="login" />
       <Stack.Screen name="register" />
+      <Stack.Screen name="forgotPassword" />
+      <Stack.Screen name="verifyEmail" />
     </Stack>
   );
 }

--- a/app/(auth)/forgotPassword.tsx
+++ b/app/(auth)/forgotPassword.tsx
@@ -1,0 +1,276 @@
+import { useRouter } from "expo-router";
+import { useColorScheme } from "nativewind";
+import React from "react";
+import {
+    ActivityIndicator,
+    Alert,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import themes from "../../constants/colors";
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
+
+export default function ForgotPassword() {
+  const router = useRouter();
+  const { top } = useSafeAreaInsets();
+  const { colorScheme } = useColorScheme();
+  const currentTheme =
+    themes[colorScheme as keyof typeof themes] ?? themes.light;
+
+  const [email, setEmail] = React.useState("");
+  const [otp, setOtp] = React.useState("");
+  const [newPassword, setNewPassword] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+  const [otpSent, setOtpSent] = React.useState(false);
+
+  const handleSendOTP = async () => {
+    if (!email.trim()) {
+      Alert.alert("Error", "Please enter your email address");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/auth/email-otp/send-verification-otp`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: `${API_BASE_URL}`,
+          },
+          body: JSON.stringify({
+            email: email.trim(),
+            type: "forget-password",
+          }),
+        }
+      );
+
+      const data = await response.json();
+
+      if (response.ok) {
+        setOtpSent(true);
+        Alert.alert(
+          "Success",
+          "Verification OTP has been sent to your email. Please check your inbox."
+        );
+      } else {
+        Alert.alert(
+          "Error",
+          data.message || "Failed to send OTP. Please try again."
+        );
+      }
+    } catch (error) {
+      Alert.alert(
+        "Error",
+        "An error occurred while sending OTP. Please try again."
+      );
+      console.error("Send OTP error:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleResetPassword = async () => {
+    if (!otp.trim() || !newPassword.trim()) {
+      Alert.alert("Error", "Please enter both OTP and new password");
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      Alert.alert(
+        "Error",
+        "Password must be at least 8 characters long"
+      );
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/auth/email-otp/reset-password`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: `${API_BASE_URL}`,
+          },
+          body: JSON.stringify({
+            email: email.trim(),
+            otp: otp.trim(),
+            password: newPassword,
+          }),
+        }
+      );
+
+      const data = await response.json();
+
+      if (response.ok) {
+        Alert.alert(
+          "Success",
+          "Your password has been reset successfully. You can now login with your new password.",
+          [
+            {
+              text: "OK",
+              onPress: () => router.replace("/(auth)/login"),
+            },
+          ]
+        );
+      } else {
+        Alert.alert(
+          "Error",
+          data.message || "Failed to reset password. Please try again."
+        );
+      }
+    } catch (error) {
+      Alert.alert(
+        "Error",
+        "An error occurred while resetting password. Please try again."
+      );
+      console.error("Reset password error:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (otpSent) {
+      handleResetPassword();
+    } else {
+      handleSendOTP();
+    }
+  };
+
+  return (
+    <View
+      className="flex-1"
+      style={{
+        paddingTop: top,
+        backgroundColor: currentTheme.background,
+      }}
+    >
+      <View className="flex-1 justify-center items-center px-4">
+        <Text
+          className="mb-4 font-bold text-4xl"
+          style={{ color: currentTheme.foreground }}
+        >
+          Forgot Password
+        </Text>
+        <Text
+          className="mb-8 text-center text-base"
+          style={{ color: currentTheme.mutedForeground }}
+        >
+          {otpSent
+            ? "Enter the OTP sent to your email and your new password"
+            : "Enter your email address to receive a verification OTP"}
+        </Text>
+
+        <TextInput
+          className="mb-4 p-4 rounded-lg w-full"
+          style={{
+            backgroundColor: otpSent
+              ? currentTheme.muted
+              : currentTheme.card,
+            color: otpSent
+              ? currentTheme.mutedForeground
+              : currentTheme.foreground,
+          }}
+          placeholder="Email"
+          placeholderTextColor={currentTheme.mutedForeground}
+          value={email}
+          onChangeText={setEmail}
+          autoCapitalize="none"
+          keyboardType="email-address"
+          editable={!otpSent}
+        />
+
+        {otpSent && (
+          <>
+            <TextInput
+              className="mb-4 p-4 rounded-lg w-full"
+              style={{
+                backgroundColor: currentTheme.card,
+                color: currentTheme.foreground,
+              }}
+              placeholder="Enter OTP"
+              placeholderTextColor={currentTheme.mutedForeground}
+              value={otp}
+              onChangeText={setOtp}
+              keyboardType="number-pad"
+              maxLength={6}
+            />
+            <TextInput
+              className="mb-8 p-4 rounded-lg w-full"
+              style={{
+                backgroundColor: currentTheme.card,
+                color: currentTheme.foreground,
+              }}
+              placeholder="New Password"
+              placeholderTextColor={currentTheme.mutedForeground}
+              value={newPassword}
+              onChangeText={setNewPassword}
+              secureTextEntry
+            />
+          </>
+        )}
+
+        {!otpSent && <View className="mb-8" />}
+
+        <TouchableOpacity
+          className="items-center p-4 rounded-lg w-full"
+          style={{ backgroundColor: currentTheme.primary }}
+          onPress={handleSubmit}
+          disabled={loading}
+        >
+          {loading ? (
+            <ActivityIndicator color={currentTheme.primaryForeground} />
+          ) : (
+            <Text
+              className="font-bold text-lg"
+              style={{ color: currentTheme.primaryForeground }}
+            >
+              {otpSent ? "Reset Password" : "Send OTP"}
+            </Text>
+          )}
+        </TouchableOpacity>
+
+        {otpSent && (
+          <TouchableOpacity
+            className="mt-4"
+            onPress={() => {
+              setOtpSent(false);
+              setOtp("");
+              setNewPassword("");
+            }}
+            disabled={loading}
+          >
+            <Text
+              className="text-base"
+              style={{ color: currentTheme.primary }}
+            >
+              Resend OTP
+            </Text>
+          </TouchableOpacity>
+        )}
+
+        <TouchableOpacity
+          className="mt-4"
+          onPress={() => router.back()}
+          disabled={loading}
+        >
+          <Text
+            className="text-base"
+            style={{ color: currentTheme.mutedForeground }}
+          >
+            Back to{" "}
+            <Text style={{ color: currentTheme.primary }}>Login</Text>
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -3,11 +3,11 @@ import { Redirect, useRouter } from "expo-router";
 import { useColorScheme } from "nativewind";
 import React from "react";
 import {
-    ActivityIndicator,
-    Text,
-    TextInput,
-    TouchableOpacity,
-    View
+  ActivityIndicator,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import themes from "../../constants/colors";
@@ -92,6 +92,17 @@ export default function Login() {
         </TouchableOpacity>
         <TouchableOpacity
           className="mt-4"
+          onPress={() => router.push("/(auth)/forgotPassword")}
+        >
+          <Text
+            className="text-base"
+            style={{ color: currentTheme.primary }}
+          >
+            Forgot Password?
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          className="mt-2"
           onPress={() => router.push("/(auth)/register")}
         >
           <Text

--- a/app/(auth)/verifyEmail.tsx
+++ b/app/(auth)/verifyEmail.tsx
@@ -1,0 +1,230 @@
+import { useAuth } from "@/context/AuthContext";
+import { useRouter } from "expo-router";
+import { useColorScheme } from "nativewind";
+import React from "react";
+import {
+    ActivityIndicator,
+    Alert,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import themes from "../../constants/colors";
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
+
+export default function VerifyEmail() {
+  const { user, session, refreshUser } = useAuth();
+  const router = useRouter();
+  const { top } = useSafeAreaInsets();
+  const { colorScheme } = useColorScheme();
+  const currentTheme =
+    themes[colorScheme as keyof typeof themes] ?? themes.light;
+
+  const [otp, setOtp] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+  const [resending, setResending] = React.useState(false);
+
+  const handleVerifyEmail = async () => {
+    if (!otp.trim()) {
+      Alert.alert("Error", "Please enter the OTP");
+      return;
+    }
+
+    if (!user?.email || !session?.accessToken) {
+      Alert.alert("Error", "Unable to verify email. Please try again.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/auth/email-otp/verify-email`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: `${API_BASE_URL}`,
+            Authorization: `Bearer ${session.accessToken}`,
+          },
+          body: JSON.stringify({
+            email: user.email,
+            otp: otp.trim(),
+          }),
+        }
+      );
+
+      const data = await response.json();
+
+      if (response.ok) {
+        Alert.alert(
+          "Success",
+          "Your email has been verified successfully!",
+          [
+            {
+              text: "OK",
+              onPress: async () => {
+                await refreshUser();
+                router.replace("/(tabs)/profile");
+              },
+            },
+          ]
+        );
+      } else {
+        Alert.alert(
+          "Error",
+          data.message || "Failed to verify email. Please check your OTP and try again."
+        );
+      }
+    } catch (error) {
+      Alert.alert(
+        "Error",
+        "An error occurred while verifying email. Please try again."
+      );
+      console.error("Verify email error:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleResendOTP = async () => {
+    if (!user?.email || !session?.accessToken) {
+      Alert.alert("Error", "Unable to resend OTP. Please try again.");
+      return;
+    }
+
+    setResending(true);
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/auth/email-otp/send-verification-otp`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: `${API_BASE_URL}`,
+            Authorization: `Bearer ${session.accessToken}`,
+          },
+          body: JSON.stringify({
+            email: user.email,
+            type: "email-verification",
+          }),
+        }
+      );
+
+      const data = await response.json();
+
+      if (response.ok) {
+        Alert.alert(
+          "Success",
+          "Verification OTP has been resent to your email."
+        );
+        setOtp("");
+      } else {
+        Alert.alert(
+          "Error",
+          data.message || "Failed to resend OTP. Please try again."
+        );
+      }
+    } catch (error) {
+      Alert.alert(
+        "Error",
+        "An error occurred while resending OTP. Please try again."
+      );
+      console.error("Resend OTP error:", error);
+    } finally {
+      setResending(false);
+    }
+  };
+
+  return (
+    <View
+      className="flex-1"
+      style={{
+        paddingTop: top,
+        backgroundColor: currentTheme.background,
+      }}
+    >
+      <View className="flex-1 justify-center items-center px-4">
+        <Text
+          className="mb-4 font-bold text-4xl"
+          style={{ color: currentTheme.foreground }}
+        >
+          Verify Email
+        </Text>
+        <Text
+          className="mb-8 text-center text-base"
+          style={{ color: currentTheme.mutedForeground }}
+        >
+          We've sent a verification code to
+        </Text>
+        <Text
+          className="mb-8 text-center font-semibold text-base"
+          style={{ color: currentTheme.primary }}
+        >
+          {user?.email}
+        </Text>
+
+        <TextInput
+          className="mb-8 p-4 rounded-lg w-full"
+          style={{
+            backgroundColor: currentTheme.card,
+            color: currentTheme.foreground,
+          }}
+          placeholder="Enter OTP"
+          placeholderTextColor={currentTheme.mutedForeground}
+          value={otp}
+          onChangeText={setOtp}
+          keyboardType="number-pad"
+          maxLength={6}
+        />
+
+        <TouchableOpacity
+          className="items-center p-4 rounded-lg w-full"
+          style={{ backgroundColor: currentTheme.primary }}
+          onPress={handleVerifyEmail}
+          disabled={loading || resending}
+        >
+          {loading ? (
+            <ActivityIndicator color={currentTheme.primaryForeground} />
+          ) : (
+            <Text
+              className="font-bold text-lg"
+              style={{ color: currentTheme.primaryForeground }}
+            >
+              Verify Email
+            </Text>
+          )}
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          className="mt-4"
+          onPress={handleResendOTP}
+          disabled={loading || resending}
+        >
+          <Text
+            className="text-base"
+            style={{ color: currentTheme.primary }}
+          >
+            {resending ? "Resending..." : "Resend OTP"}
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          className="mt-4"
+          onPress={() => router.back()}
+          disabled={loading || resending}
+        >
+          <Text
+            className="text-base"
+            style={{ color: currentTheme.mutedForeground }}
+          >
+            Back to{" "}
+            <Text style={{ color: currentTheme.primary }}>Profile</Text>
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -27,12 +27,13 @@ function RootLayoutNav() {
   useEffect(() => {
     const inAuthGroup = segments[0] === "(auth)";
     const inTabsGroup = segments[0] === "(tabs)";
+    const isVerifyEmail = segments[0] === "(auth)" && segments[1] === "verifyEmail";
 
     if (!session && inTabsGroup) {
       // User is not authenticated but trying to access protected routes
       router.replace("/(auth)/login");
-    } else if (session && inAuthGroup) {
-      // User is authenticated but on auth pages
+    } else if (session && inAuthGroup && !isVerifyEmail) {
+      // User is authenticated but on auth pages (except verifyEmail)
       router.replace("/(tabs)");
     }
   }, [session, segments]);

--- a/app/profile/index.tsx
+++ b/app/profile/index.tsx
@@ -5,13 +5,13 @@ import { Baby, ChevronRight, HelpCircle, LogIn, LogOut, Settings, Shield, User }
 import { useColorScheme } from 'nativewind'
 import React, { useEffect, useState } from 'react'
 import {
-    ActivityIndicator,
-    Alert,
-    ScrollView,
-    StyleSheet,
-    Text,
-    TouchableOpacity,
-    View
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
@@ -88,13 +88,55 @@ const ProfileScreen = () => {
     fetchChildren();
   }, [session, user]);
 
+  const handleVerifyEmail = async () => {
+    if (!session?.accessToken || !user?.email) {
+      Alert.alert('Error', 'Unable to verify email. Please try again.');
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/auth/email-otp/send-verification-otp`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Origin': `${API_BASE_URL}`,
+            'Authorization': `Bearer ${session.accessToken}`,
+          },
+          body: JSON.stringify({
+            email: user.email,
+            type: 'email-verification',
+          }),
+        }
+      );
+
+      const data = await response.json();
+
+      if (response.ok) {
+        router.push('/(auth)/verifyEmail');
+      } else {
+        Alert.alert(
+          'Error',
+          data.message || 'Failed to send verification OTP. Please try again.'
+        );
+      }
+    } catch (error) {
+      Alert.alert(
+        'Error',
+        'An error occurred while sending verification OTP. Please try again.'
+      );
+      console.error('Send verification OTP error:', error);
+    }
+  };
+
   const menuItems = [
     ...(session && user?.emailVerified === false ? [{
       id: 'verify-email',
       title: 'Verify Email',
       subtitle: 'Verify your email address to secure your account',
       icon: Shield,
-      onPress: () => Alert.alert('Email Verification', 'Email verification feature will be available soon')
+      onPress: handleVerifyEmail
     }] : []),
     {
       id: 'account',


### PR DESCRIPTION
Introduce forgotPassword and verifyEmail screens for email OTP-based password reset and email verification. Register both screens in the (auth) layout and add navigation from the login screen to Forgot Password. Add a 'Verify Email' action in the profile that requests a verification OTP and navigates to the Verify Email screen. Update root layout routing to allow authenticated users to access the verifyEmail route (prevent redirect to tabs) while still protecting other auth routes. Uses EXPO_PUBLIC_API_URL for API calls and includes basic loading/error handling and UI theming.