### PR TITLE
AI support: save/unsave messages & UI updates

### DIFF
--- a/app/aiSupport/SavedResponses.tsx
+++ b/app/aiSupport/SavedResponses.tsx
@@ -1,6 +1,6 @@
 import themes from '@/constants/colors'
 import { useAuth } from '@/context/AuthContext'
-import { ArrowLeft, Bookmark, RefreshCw } from 'lucide-react-native'
+import { ArrowLeft, Bookmark, RefreshCw, Trash2 } from 'lucide-react-native'
 import { useColorScheme } from 'nativewind'
 import React, { useState } from 'react'
 import {
@@ -15,13 +15,20 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL
 
-interface Memory {
+interface Timestamp {
+  seconds: number
+  nanoseconds: number
+}
+
+interface SavedMessage {
   id: string
-  title: string
-  text: string
-  createdAt: string
-  isAiResponse: boolean
+  createdAt: Timestamp
+  sessionId: string
   userId: string
+  content: string
+  metadata: any
+  role: 'user' | 'model'
+  isSaved: boolean
 }
 
 interface SavedResponsesProps {
@@ -34,40 +41,98 @@ const SavedResponses: React.FC<SavedResponsesProps> = ({ onBack }) => {
   const { colorScheme } = useColorScheme()
   const currentTheme = themes[colorScheme || 'light'] ?? themes.light
 
-  const [savedAnswers, setSavedAnswers] = useState<Memory[]>([])
+  const [savedAnswers, setSavedAnswers] = useState<SavedMessage[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [expandedAnswer, setExpandedAnswer] = useState<string | null>(null)
+  const [unsavingIds, setUnsavingIds] = useState<Set<string>>(new Set())
 
   const getAuthHeaders = () => ({
     'Authorization': `Bearer ${token}`,
     'Content-Type': 'application/json',
   })
 
+  const formatRelativeTime = (timestamp: Timestamp): string => {
+    const now = Date.now()
+    const messageTime = timestamp.seconds * 1000
+    const diffInSeconds = Math.floor((now - messageTime) / 1000)
+
+    if (diffInSeconds < 60) return 'Just now'
+    if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}m ago`
+    if (diffInSeconds < 86400) return `${Math.floor(diffInSeconds / 3600)}h ago`
+    if (diffInSeconds < 604800) return `${Math.floor(diffInSeconds / 86400)}d ago`
+    return `${Math.floor(diffInSeconds / 604800)}w ago`
+  }
+
   const fetchSavedAnswers = async () => {
     if (!token) return
 
     setIsLoading(true)
     try {
-      const url = `${API_BASE_URL}/memories?isAiResponse=true`
+      const url = `${API_BASE_URL}/ai-support/message/saved`
 
       const response = await fetch(url, {
         headers: getAuthHeaders(),
       })
-
 
       if (!response.ok) {
         const errorText = await response.text()
         throw new Error(`Failed to fetch saved answers: ${response.status}`)
       }
 
-      const fetchedMemories = await response.json()
-      setSavedAnswers(fetchedMemories)
+      const fetchedMessages: SavedMessage[] = await response.json()
+      setSavedAnswers(fetchedMessages)
     } catch (error) {
       console.error('Error fetching saved answers:', error)
       Alert.alert('Error', 'Failed to load saved answers')
     } finally {
       setIsLoading(false)
     }
+  }
+
+  const unsaveMessage = async (messageId: string) => {
+    if (!token) return
+
+    Alert.alert(
+      'Unsave Response',
+      'Are you sure you want to remove this saved response?',
+      [
+        {
+          text: 'Cancel',
+          style: 'cancel'
+        },
+        {
+          text: 'Remove',
+          style: 'destructive',
+          onPress: async () => {
+            setUnsavingIds(prev => new Set(prev).add(messageId))
+            
+            try {
+              const response = await fetch(`${API_BASE_URL}/ai-support/message/${messageId}`, {
+                method: 'PUT',
+                headers: getAuthHeaders(),
+                body: JSON.stringify({ isSaved: false })
+              })
+
+              if (!response.ok) {
+                throw new Error(`Failed to unsave message: ${response.status}`)
+              }
+
+              // Remove from local state
+              setSavedAnswers(prev => prev.filter(msg => msg.id !== messageId))
+            } catch (error) {
+              console.error('Error unsaving message:', error)
+              Alert.alert('Error', 'Failed to remove saved response')
+            } finally {
+              setUnsavingIds(prev => {
+                const newSet = new Set(prev)
+                newSet.delete(messageId)
+                return newSet
+              })
+            }
+          }
+        }
+      ]
+    )
   }
 
   React.useEffect(() => {
@@ -166,40 +231,50 @@ const SavedResponses: React.FC<SavedResponsesProps> = ({ onBack }) => {
           contentContainerStyle={{ padding: 16 }}
           showsVerticalScrollIndicator={false}
         >
-          {savedAnswers.map((memory) => (
+          {savedAnswers.map((message) => {
+            const isUnsaving = unsavingIds.has(message.id)
+            
+            return (
             <View
-              key={memory.id}
+              key={message.id}
               style={{
                 backgroundColor: currentTheme.card,
                 borderRadius: 12,
                 padding: 16,
                 marginBottom: 12,
                 borderWidth: 1,
-                borderColor: currentTheme.border
+                borderColor: currentTheme.border,
+                opacity: isUnsaving ? 0.5 : 1
               }}
             >
-              {/* Title and Date */}
+              {/* Header with Date and Unsave Button */}
               <View style={{
                 flexDirection: 'row',
                 justifyContent: 'space-between',
-                alignItems: 'flex-start',
+                alignItems: 'center',
                 marginBottom: 12
               }}>
-                <Text style={{
-                  fontSize: 16,
-                  fontWeight: '600',
-                  color: currentTheme.foreground,
-                  flex: 1,
-                  marginRight: 8
-                }}>
-                  {memory.title}
-                </Text>
                 <Text style={{
                   fontSize: 12,
                   color: currentTheme.mutedForeground
                 }}>
-                  {memory.createdAt}
+                  {formatRelativeTime(message.createdAt)}
                 </Text>
+                <TouchableOpacity
+                  onPress={() => unsaveMessage(message.id)}
+                  disabled={isUnsaving}
+                  style={{
+                    padding: 6,
+                    borderRadius: 8,
+                    backgroundColor: currentTheme.destructive || '#ef4444'
+                  }}
+                >
+                  {isUnsaving ? (
+                    <ActivityIndicator size="small" color="white" />
+                  ) : (
+                    <Trash2 size={16} color="white" />
+                  )}
+                </TouchableOpacity>
               </View>
 
               {/* Response Text */}
@@ -208,14 +283,14 @@ const SavedResponses: React.FC<SavedResponsesProps> = ({ onBack }) => {
                 color: currentTheme.foreground,
                 lineHeight: 20,
                 marginBottom: 12
-              }} numberOfLines={expandedAnswer === memory.id ? undefined : 3}>
-                {memory.text}
+              }} numberOfLines={expandedAnswer === message.id ? undefined : 3}>
+                {message.content}
               </Text>
 
               {/* Expand/Collapse Button */}
-              {memory.text.length > 150 && (
+              {message.content.length > 150 && (
                 <TouchableOpacity
-                  onPress={() => toggleExpanded(memory.id)}
+                  onPress={() => toggleExpanded(message.id)}
                   style={{
                     alignSelf: 'flex-start'
                   }}
@@ -225,12 +300,12 @@ const SavedResponses: React.FC<SavedResponsesProps> = ({ onBack }) => {
                     fontSize: 14,
                     fontWeight: '500'
                   }}>
-                    {expandedAnswer === memory.id ? 'Show Less' : 'Show More'}
+                    {expandedAnswer === message.id ? 'Show Less' : 'Show More'}
                   </Text>
                 </TouchableOpacity>
               )}
             </View>
-          ))}
+          )})}
         </ScrollView>
       )}
     </SafeAreaView>

--- a/app/aiSupport/index.tsx
+++ b/app/aiSupport/index.tsx
@@ -226,6 +226,11 @@ const AiSupportScreen = ({ initialQuestion }: AiSupportScreenProps = {}) => {
       
       // Refresh sessions list to show updated title/timestamp
       fetchSessions()
+      
+      // Refetch session messages to sync with actual message IDs from backend
+      if (data.sessionId) {
+        await fetchSessionMessages(data.sessionId)
+      }
     } catch (error) {
       console.error('Error sending message:', error)
       Alert.alert('Error', `Failed to send message: ${error instanceof Error ? error.message : 'Unknown error'}`)
@@ -235,7 +240,7 @@ const AiSupportScreen = ({ initialQuestion }: AiSupportScreenProps = {}) => {
   }
 
   const saveResponse = async (message: Message) => {
-    if (!token || !message.questionForAi) return
+    if (!token) return
 
     // Update message to show saving state
     setMessages(prev => prev.map(msg =>
@@ -243,19 +248,11 @@ const AiSupportScreen = ({ initialQuestion }: AiSupportScreenProps = {}) => {
     ))
 
     try {
-      const formData = new FormData()
-      formData.append('title', `AI: ${message.questionForAi}`)
-      formData.append('text', message.text)
-      formData.append('isAiResponse', 'true')
-
-      const response = await fetch(`${API_BASE_URL}/memories`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-        body: formData
+      const response = await fetch(`${API_BASE_URL}/ai-support/message/${message.id}`, {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+        body: JSON.stringify({ isSaved: true })
       })
-
 
       if (!response.ok) {
         const errorText = await response.text()
@@ -364,6 +361,11 @@ const AiSupportScreen = ({ initialQuestion }: AiSupportScreenProps = {}) => {
           }
 
           setMessages(prev => [...prev, aiMessage])
+          
+          // Refetch session messages to sync with actual message IDs from backend
+          if (data.sessionId) {
+            await fetchSessionMessages(data.sessionId)
+          }
         } catch (error) {
           console.error('Error sending message:', error)
           Alert.alert('Error', `Failed to send message: ${error instanceof Error ? error.message : 'Unknown error'}`)


### PR DESCRIPTION
Switch saved-messages handling to the ai-support API and update types/UI. Replaced the old Memory model with SavedMessage/Timestamp, updated fetch endpoints (/ai-support/message/saved and /ai-support/message/:id), and changed save to a PUT that toggles isSaved. Added relative time formatting, an Unsave flow with confirmation and loading state (Trash icon + spinner), and optimistic local state updates. Also refetch session messages after sending/saving to sync backend-assigned IDs and adjusted UI text/content fields and expand/collapse logic accordingly.